### PR TITLE
fix(mysql): map date, mediumint, varbinary and json instead of panicking

### DIFF
--- a/connector_arrow/src/mysql/mod.rs
+++ b/connector_arrow/src/mysql/mod.rs
@@ -71,18 +71,19 @@ impl<Q: Queryable> Connector for MySQLConnection<Q> {
 
             ("tinyint" | "bool" | "boolean", false) => DataType::Int8,
             ("smallint", false) => DataType::Int16,
-            ("integer" | "int", false) => DataType::Int32,
+            // MEDIUMINT is a 24-bit integer; it fits Int32/UInt32.
+            ("integer" | "int" | "mediumint", false) => DataType::Int32,
             ("bigint", false) => DataType::Int64,
 
             ("tinyint", true) => DataType::UInt8,
             ("smallint", true) => DataType::UInt16,
-            ("integer" | "int", true) => DataType::UInt32,
+            ("integer" | "int" | "mediumint", true) => DataType::UInt32,
             ("bigint", true) => DataType::UInt64,
 
             ("real" | "float" | "float4", _) => DataType::Float32,
             ("double" | "float8", _) => DataType::Float64,
 
-            ("bit" | "tinyblob" | "mediumblob" | "longblob" | "blob" | "binary", _) => {
+            ("bit" | "tinyblob" | "mediumblob" | "longblob" | "blob" | "binary" | "varbinary", _) => {
                 DataType::Binary
             }
 
@@ -91,6 +92,11 @@ impl<Q: Queryable> Connector for MySQLConnection<Q> {
             }
 
             ("decimal" | "numeric" | "newdecimal", _) => DataType::Utf8,
+
+            // MySQL (8.0+) sends JSON columns as MYSQL_TYPE_JSON; values arrive as
+            // Value::Bytes containing the JSON text, so Utf8 is the natural mapping.
+            // (MariaDB aliases JSON to LONGTEXT, which is covered by the text arm above.)
+            ("json", _) => DataType::Utf8,
 
             // MySQL DATETIME has range 1000-01-01 00:00:00.000000 and
             // 9999-12-31 23:59:59.999999 with microsecond precision.
@@ -101,7 +107,7 @@ impl<Q: Queryable> Connector for MySQLConnection<Q> {
             // So we default to Utf8.
             // TODO: if we send `SET timezone = 'UTC'` before executing queries, we could convert
             // to timestamp in 'UTC' timezone.
-            ("datetime" | "timestamp", _) => DataType::Utf8,
+            ("date" | "datetime" | "timestamp", _) => DataType::Utf8,
 
             _ => return None,
         })

--- a/connector_arrow/tests/it/test_mysql.rs
+++ b/connector_arrow/tests/it/test_mysql.rs
@@ -67,6 +67,8 @@ fn roundtrip(#[case] table_name: &str, #[case] spec: spec::ArrowGenSpec) {
 #[case::strings(literals_cases::strings())]
 #[case::decimals(literals_cases::decimals())]
 #[case::timestamp(literals_cases::timestamp())]
+#[case::date(literals_cases::date())]
+#[case::varbinary(literals_cases::varbinary())]
 fn query_literals(#[case] queries: Vec<QueryOfSingleLiteral>) {
     let mut conn = init();
     crate::util::query_literals(&mut conn, queries)
@@ -104,5 +106,27 @@ mod literals_cases {
                 value: Box::new("2024-02-23T15:18:36.000000".to_string()),
             },
         ]
+    }
+
+    pub fn date() -> Vec<QueryOfSingleLiteral> {
+        // DATE values arrive over the wire as Value::Date with a zero time part,
+        // rendered by the Utf8 producer in the same fixed-width format as DATETIME.
+        vec![QueryOfSingleLiteral {
+            db_ty: "DATE".into(),
+            value_sql: "DATE'2024-02-23'".into(),
+            inject_sql_cast: false,
+            value: Box::new("2024-02-23T00:00:00.000000".to_string()),
+        }]
+    }
+
+    pub fn varbinary() -> Vec<QueryOfSingleLiteral> {
+        // A bare hex literal is sent as MYSQL_TYPE_VAR_STRING with the BINARY flag,
+        // which get_name_of_column_type reports as "varbinary".
+        vec![QueryOfSingleLiteral {
+            db_ty: "VARBINARY".into(),
+            value_sql: "x'DEADBEEF'".into(),
+            inject_sql_cast: false,
+            value: Box::new(vec![0xDEu8, 0xAD, 0xBE, 0xEF]),
+        }]
     }
 }


### PR DESCRIPTION
type_db_into_arrow returns None for several types that MySQL/MariaDB commonly send over the wire, and create_field turns that None into todo!(), so querying any table (or literal) with one of these column types panics the whole process:

- DATE (MYSQL_TYPE_DATE): values already arrive as Value::Bytes/Value::Date and the Utf8 producer renders them (same fixed-width form as DATETIME), only the schema mapping was missing -> map to Utf8 alongside datetime/timestamp.
- MEDIUMINT / MEDIUMINT UNSIGNED (MYSQL_TYPE_INT24): 24-bit integer, fits the existing Int32/UInt32 producers -> add to the int arms.
- VARBINARY (MYSQL_TYPE_VAR_STRING + BINARY flag): get_name_of_column_type already reports it as "varbinary", but the Binary arm only listed "binary" -> add it. This also covers bare hex literals like SELECT x'DEADBEEF'.
- JSON (MYSQL_TYPE_JSON, MySQL 8.0+): values arrive as Value::Bytes containing the JSON text -> map to Utf8. (MariaDB aliases JSON to LONGTEXT and was already covered by the text arm.)

Add query_literals cases for DATE and VARBINARY (both reachable via literals). MEDIUMINT and JSON cannot be produced by a cast/literal on the MariaDB test database, so they carry no literal case; the mapping is exercised by any real table containing such a column.